### PR TITLE
Switch to env var for WorkflowAI key

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ Lancez le serveur Node puis ouvrez votre navigateur sur [http://localhost:3000](
 npm start
 ```
 
-Le champ texte permet de saisir le nom d'une entreprise. Lorsque vous cliquez sur **Analyser**, le serveur appelle le service WorkflowAI pour générer l'analyse SWOT et affiche les forces, faiblesses, opportunités et menaces retournées.
+Le champ texte permet de saisir le nom d'une entreprise. Lorsque vous cliquez sur **Analyser**, le serveur envoie une requête REST au service WorkflowAI pour générer l'analyse SWOT et affiche les forces, faiblesses, opportunités et menaces retournées.
 
-Le service nécessite une clé API WorkflowAI. Vous pouvez la fournir via la variable d'environnement `WORKFLOWAI_API_KEY` avant de démarrer le serveur.
+Le service nécessite une clé API WorkflowAI. Vous pouvez la fournir via la variable d'environnement `WORKFLOWAI_API_KEY` avant de démarrer le serveur. Par exemple :
+
+```bash
+WORKFLOWAI_API_KEY=wai-yS7LWhHODAVtQAb4_sD880sAU2rzKjnxpBQDj1PmBww npm start
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,22 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@workflowai/workflowai": "^1.6.7",
         "express": "^5.1.0"
-      }
-    },
-    "node_modules/@workflowai/workflowai": {
-      "version": "1.6.7",
-      "resolved": "https://registry.npmjs.org/@workflowai/workflowai/-/workflowai-1.6.7.tgz",
-      "integrity": "sha512-sYb2B39KFqVOy4NCa5gPMWM+ZgQ5DfzLLFuTR2Sqi6fwgzKG1vw8CaI+WKyfACb91fqnFAhkEP5NCvqgCvRP1A==",
-      "dependencies": {
-        "fetch-event-stream": "^0.1.5",
-        "fetch-retry": "^6.0.0",
-        "openapi-fetch": "^0.9.8",
-        "zod": "^3.23.8"
-      },
-      "engines": {
-        "node": ">=18.13"
       }
     },
     "node_modules/accepts": {
@@ -278,18 +263,6 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
-    },
-    "node_modules/fetch-event-stream": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/fetch-event-stream/-/fetch-event-stream-0.1.5.tgz",
-      "integrity": "sha512-V1PWovkspxQfssq/NnxoEyQo1DV+MRK/laPuPblIZmSjMN8P5u46OhlFQznSr9p/t0Sp8Uc6SbM3yCMfr0KU8g==",
-      "license": "MIT"
-    },
-    "node_modules/fetch-retry": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/fetch-retry/-/fetch-retry-6.0.0.tgz",
-      "integrity": "sha512-BUFj1aMubgib37I3v4q78fYo63Po7t4HUPTpQ6/QE6yK6cIQrP+W43FYToeTEyg5m2Y7eFUtijUuAv/PDlWuag==",
-      "license": "MIT"
     },
     "node_modules/finalhandler": {
       "version": "2.1.0",
@@ -564,21 +537,6 @@
       "dependencies": {
         "wrappy": "1"
       }
-    },
-    "node_modules/openapi-fetch": {
-      "version": "0.9.8",
-      "resolved": "https://registry.npmjs.org/openapi-fetch/-/openapi-fetch-0.9.8.tgz",
-      "integrity": "sha512-zM6elH0EZStD/gSiNlcPrzXcVQ/pZo3BDvC6CDwRDUt1dDzxlshpmQnpD6cZaJ39THaSmwVCxxRrPKNM1hHrDg==",
-      "license": "MIT",
-      "dependencies": {
-        "openapi-typescript-helpers": "^0.0.8"
-      }
-    },
-    "node_modules/openapi-typescript-helpers": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/openapi-typescript-helpers/-/openapi-typescript-helpers-0.0.8.tgz",
-      "integrity": "sha512-1eNjQtbfNi5Z/kFhagDIaIRj6qqDzhjNJKz8cmMW0CVdGwT6e1GLbAfgI0d28VTJa1A8jz82jm/4dG8qNoNS8g==",
-      "license": "MIT"
     },
     "node_modules/parseurl": {
       "version": "1.3.3",
@@ -862,15 +820,6 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
-    },
-    "node_modules/zod": {
-      "version": "3.25.63",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.63.tgz",
-      "integrity": "sha512-3ttCkqhtpncYXfP0f6dsyabbYV/nEUW+Xlu89jiXbTBifUfjaSqXOG6JnQPLtqt87n7KAmnMqcjay6c0Wq0Vbw==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
   "license": "ISC",
   "type": "module",
   "dependencies": {
-    "@workflowai/workflowai": "^1.6.7",
     "express": "^5.1.0"
   }
 }


### PR DESCRIPTION
## Summary
- require `WORKFLOWAI_API_KEY` instead of embedding it in the code
- document how to start the server with the provided API key

## Testing
- `node --check server.js`
- `npm install --package-lock-only`


------
https://chatgpt.com/codex/tasks/task_e_684b3fc744a88320af4b78ca6d889ee7