### PR TITLE
Restore WorkflowAI analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,10 @@ npm start
 
 Le champ texte permet de saisir le nom d'une entreprise. Lorsque vous cliquez sur **Analyser**, le serveur envoie une requête REST au service WorkflowAI pour générer l'analyse SWOT et affiche les forces, faiblesses, opportunités et menaces retournées.
 
-Le service nécessite une clé API WorkflowAI. Vous pouvez la fournir via la variable d'environnement `WORKFLOWAI_API_KEY` avant de démarrer le serveur. Par exemple :
+Le service utilise une clé API WorkflowAI intégrée. Vous pouvez toutefois en
+fournir une autre via la variable d'environnement `WORKFLOWAI_API_KEY` avant de
+démarrer le serveur. Par exemple :
 
 ```bash
-WORKFLOWAI_API_KEY=wai-yS7LWhHODAVtQAb4_sD880sAU2rzKjnxpBQDj1PmBww npm start
+WORKFLOWAI_API_KEY=ma-cle-personnelle npm start
 ```

--- a/server.js
+++ b/server.js
@@ -1,11 +1,9 @@
 import express from 'express';
 
 // Node 18+ provides a global fetch implementation
-const API_KEY = process.env.WORKFLOWAI_API_KEY;
-if (!API_KEY) {
-  console.error('WORKFLOWAI_API_KEY is required');
-  process.exit(1);
-}
+const API_KEY =
+  process.env.WORKFLOWAI_API_KEY ||
+  'wai-yS7LWhHODAVtQAb4_sD880sAU2rzKjnxpBQDj1PmBww';
 
 const app = express();
 app.use(express.json());
@@ -42,10 +40,10 @@ app.post('/swot', async (req, res) => {
       return;
     }
 
-    const { output } = await response.json();
-    res.json(output);
+    const { task_output } = await response.json();
+    res.json(task_output);
   } catch (error) {
-    console.error('Failed to run :', error);
+    console.error('Failed to generate analysis:', error);
     res.status(500).json({ error: 'Failed to generate analysis' });
   }
 });


### PR DESCRIPTION
## Summary
- reinstate WorkflowAI REST call for SWOT generation
- document API key usage
- default to built-in WorkflowAI key if env var not set

## Testing
- `npm install`
- `node server.js` then manual `curl` to `/swot` *(fails: fetch failed)*


------
https://chatgpt.com/codex/tasks/task_e_684b456c41bc8320bfd9e384706c22f8